### PR TITLE
Specify Long Description Content Type.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,13 +15,14 @@ with open(os.path.join(os.path.abspath(os.path.dirname(__file__)),
 
 setuptools.setup(
     name='wavefront-sdk-python',
-    version='1.1.0',
+    version='1.1.1',
     author='Wavefront by VMware',
     author_email='chitimba@wavefront.com',
     url='https://github.com/wavefrontHQ/wavefront-sdk-python',
     license='Apache-2.0',
     description='Wavefront Python SDK',
     long_description=LONG_DESCRIPTION,
+    long_description_content_type='text/markdown',
     keywords=[
         'Wavefront',
         'Wavefront SDK'

--- a/wavefront_sdk/__init__.py
+++ b/wavefront_sdk/__init__.py
@@ -8,7 +8,7 @@ spans to Wavefront via proxy or direct ingestion.
 
 @author Hao Song (songhao@vmware.com)
 """
-__version__ = '1.1.0'
+__version__ = '1.1.1'
 
 from wavefront_sdk.direct import WavefrontDirectClient
 from wavefront_sdk.proxy import WavefrontProxyClient


### PR DESCRIPTION
Explicit content type specification is needed to fix the long description rendering on PyPI
https://test.pypi.org/project/wavefront-sdk-python/1.1.0/