### PR TITLE
Add cython dependency for tdigest

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open(os.path.join(os.path.abspath(os.path.dirname(__file__)),
 
 setuptools.setup(
     name='wavefront-sdk-python',
-    version='1.1.4',
+    version='1.1.5',
     author='Wavefront by VMware',
     author_email='chitimba@wavefront.com',
     url='https://github.com/wavefrontHQ/wavefront-sdk-python',
@@ -39,6 +39,7 @@ setuptools.setup(
                                                'tests.*', 'tests')),
     install_requires=(
         'requests>=2.18.4',
-        'tdigest>=0.5.2'
+        'tdigest>=0.5.2',
+        'cython>=0.29.7'
         )
 )


### PR DESCRIPTION
Add cython dependency. This is required for AWS lambda to execute .pyx files coming from tdigest dependency.

This addresses: https://github.com/wavefrontHQ/wavefront-pyformance/issues/22 