### PR TITLE
Add socket timeout to proxy client

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open(os.path.join(os.path.abspath(os.path.dirname(__file__)),
 
 setuptools.setup(
     name='wavefront-sdk-python',
-    version='1.2.4',
+    version='1.2.5',
     author='Wavefront by VMware',
     author_email='chitimba@wavefront.com',
     url='https://github.com/wavefrontHQ/wavefront-sdk-python',

--- a/wavefront_sdk/common/proxy_connection_handler.py
+++ b/wavefront_sdk/common/proxy_connection_handler.py
@@ -11,12 +11,14 @@ import socket
 from . import connection_handler
 
 
+# pylint: disable=too-many-instance-attributes
 class ProxyConnectionHandler(connection_handler.ConnectionHandler):
     """Connection Handler.
 
     For sending data to a Wavefront proxy listening on a given port.
     """
 
+    # pylint: disable=too-many-arguments
     def __init__(self, address, port, wavefront_sdk_metrics_registry,
                  entity_prefix=None, timeout=None):
         """Construct ProxyConnectionHandler.

--- a/wavefront_sdk/common/proxy_connection_handler.py
+++ b/wavefront_sdk/common/proxy_connection_handler.py
@@ -18,7 +18,7 @@ class ProxyConnectionHandler(connection_handler.ConnectionHandler):
     """
 
     def __init__(self, address, port, wavefront_sdk_metrics_registry,
-                 entity_prefix=None):
+                 entity_prefix=None, timeout=None):
         """Construct ProxyConnectionHandler.
 
         @param address: Proxy Address
@@ -28,6 +28,7 @@ class ProxyConnectionHandler(connection_handler.ConnectionHandler):
         self._address = address
         self._port = int(port)
         self.entity_prefix = '' if not entity_prefix else entity_prefix + ''
+        self.timeout = timeout
         self.wf_metrics_registry = wavefront_sdk_metrics_registry
         self._write_successes = self.wf_metrics_registry.new_counter(
             self.entity_prefix + 'write.success')
@@ -39,6 +40,7 @@ class ProxyConnectionHandler(connection_handler.ConnectionHandler):
         """Initialize socket and connect to given address:port."""
         self._reconnecting_socket = socket.socket(socket.AF_INET,
                                                   socket.SOCK_STREAM)
+        self._reconnecting_socket.settimeout(self.timeout)
         self._reconnecting_socket.connect((self._address, self._port))
 
     def close(self):

--- a/wavefront_sdk/proxy.py
+++ b/wavefront_sdk/proxy.py
@@ -27,6 +27,7 @@ class WavefrontProxyClient(entities.WavefrontMetricSender,
     when exceptions are thrown from any methods.
     """
 
+    # pylint: disable=too-many-arguments
     def __init__(self, host, metrics_port, distribution_port, tracing_port,
                  timeout=None):
         """Construct Proxy Client.

--- a/wavefront_sdk/proxy.py
+++ b/wavefront_sdk/proxy.py
@@ -27,7 +27,7 @@ class WavefrontProxyClient(entities.WavefrontMetricSender,
     when exceptions are thrown from any methods.
     """
 
-    def __init__(self, host, metrics_port, distribution_port, tracing_port):
+    def __init__(self, host, metrics_port, distribution_port, tracing_port, timeout=None):
         """Construct Proxy Client.
 
         @param host: Hostname of the Wavefront proxy, 2878 by default
@@ -37,6 +37,8 @@ class WavefrontProxyClient(entities.WavefrontMetricSender,
         Distribution Port on which the Wavefront proxy is listening on
         @param tracing_port:
         Tracing Port on which the Wavefront proxy is listening on
+        @param timeout:
+        Timeout to set on socket connecting to proxy
         """
         self.proxy_host = host
         self.metrics_port = metrics_port
@@ -51,17 +53,20 @@ class WavefrontProxyClient(entities.WavefrontMetricSender,
             None if metrics_port is None
             else ProxyConnectionHandler(host, metrics_port,
                                         self._sdk_metrics_registry,
-                                        'metricHandler'))
+                                        'metricHandler',
+                                        timeout=timeout))
         self._histogram_proxy_connection_handler = (
             None if distribution_port is None
             else ProxyConnectionHandler(host, distribution_port,
                                         self._sdk_metrics_registry,
-                                        'histogramHandler'))
+                                        'histogramHandler',
+                                        timeout=timeout))
         self._tracing_proxy_connection_handler = (
             None if tracing_port is None
             else ProxyConnectionHandler(host, tracing_port,
                                         self._sdk_metrics_registry,
-                                        'tracingHandler'))
+                                        'tracingHandler',
+                                        timeout=timeout))
         self._default_source = gethostname()
 
         self._points_discarded = self._sdk_metrics_registry.new_counter(

--- a/wavefront_sdk/proxy.py
+++ b/wavefront_sdk/proxy.py
@@ -27,7 +27,8 @@ class WavefrontProxyClient(entities.WavefrontMetricSender,
     when exceptions are thrown from any methods.
     """
 
-    def __init__(self, host, metrics_port, distribution_port, tracing_port, timeout=None):
+    def __init__(self, host, metrics_port, distribution_port, tracing_port,
+                 timeout=None):
         """Construct Proxy Client.
 
         @param host: Hostname of the Wavefront proxy, 2878 by default


### PR DESCRIPTION
Currently, the only way to timeout the socket connection is via `setdefaulttimeout`. Rather than having this workaround in client implementations, this would be a nice addition to the proxy client interface.