### PR TITLE
Update supported Python versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Although this library is mostly used by the other Wavefront Python SDKs to send 
 
 ## Prerequisites
 
-* Python 3.6 and up are supported.
+* Python versions 3.6 - 3.9 are supported.
 * Install `wavefront-sdk-python`
     ```
     pip install wavefront-sdk-python

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Although this library is mostly used by the other Wavefront Python SDKs to send 
 
 ## Prerequisites
 
-* Python ~~2.7+~~ and Python 3.x are supported.
+* Python 3.6 and up are supported.
 * Install `wavefront-sdk-python`
     ```
     pip install wavefront-sdk-python

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(os.path.join(os.path.abspath(os.path.dirname(__file__)),
 
 setuptools.setup(
     name='wavefront-sdk-python',
-    version='1.8.3',  # The version number. Update with each pull request.
+    version='1.8.4',  # The version number. Update with each pull request.
     author='Wavefront by VMware',
     author_email='chitimba@wavefront.com',
     url='https://github.com/wavefrontHQ/wavefront-sdk-python',

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(os.path.join(os.path.abspath(os.path.dirname(__file__)),
 
 setuptools.setup(
     name='wavefront-sdk-python',
-    version='1.8.2',  # The version number. Update with each pull request.
+    version='1.8.3',  # The version number. Update with each pull request.
     author='Wavefront by VMware',
     author_email='chitimba@wavefront.com',
     url='https://github.com/wavefrontHQ/wavefront-sdk-python',
@@ -28,10 +28,10 @@ setuptools.setup(
         ],
     classifiers=[
         'License :: OSI Approved :: Apache Software License',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7'
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         ],
     include_package_data=True,
     packages=setuptools.find_packages(exclude=('*.tests', '*.tests.*',


### PR DESCRIPTION
Used as guidance: https://devguide.python.org/#status-of-python-branches

- Removed references to 2.x
- Removed 3.5 since it is EOL
- Tried adding 3.10, but isn't yet available on [Travis CI](https://travis-ci.community/t/add-python-3-10/12220/3)