### PR TITLE
Add support for providing different queue implementations for the internal buffers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(os.path.join(os.path.abspath(os.path.dirname(__file__)),
 
 setuptools.setup(
     name='wavefront-sdk-python',
-    version='1.8.4',  # The version number. Update with each pull request.
+    version='1.8.5',  # The version number. Update with each pull request.
     author='Wavefront by VMware',
     url='https://github.com/wavefrontHQ/wavefront-sdk-python',
     license='Apache-2.0',

--- a/wavefront_sdk/client.py
+++ b/wavefront_sdk/client.py
@@ -78,7 +78,7 @@ class WavefrontClient(connection_handler.ConnectionHandler,
         self._event_headers = {'Content-Type': 'application/json',
                                'Content-Encoding': 'gzip'}
         self._closed = False
-        self._schedule_lock = threading.Lock()
+        self._schedule_lock = threading.RLock()
         self._timer = None
         self._schedule_timer()
 

--- a/wavefront_sdk/client.py
+++ b/wavefront_sdk/client.py
@@ -43,7 +43,8 @@ class WavefrontClient(connection_handler.ConnectionHandler,
     EVENT_END_POINT = '/api/v2/event'
 
     def __init__(self, server, token, max_queue_size=50000, batch_size=10000,
-                 flush_interval_seconds=5, enable_internal_metrics=True):
+                 flush_interval_seconds=5, enable_internal_metrics=True,
+                 queue_impl=queue.Queue):
         # pylint: disable=too-many-arguments,too-many-statements
         """Construct Direct Client.
 
@@ -68,11 +69,11 @@ class WavefrontClient(connection_handler.ConnectionHandler,
         self._batch_size = batch_size
         self._flush_interval_seconds = flush_interval_seconds
         self._default_source = socket.gethostname() or 'unknown'
-        self._metrics_buffer = queue.Queue(max_queue_size)
-        self._histograms_buffer = queue.Queue(max_queue_size)
-        self._tracing_spans_buffer = queue.Queue(max_queue_size)
-        self._spans_log_buffer = queue.Queue(max_queue_size)
-        self._events_buffer = queue.Queue(max_queue_size)
+        self._metrics_buffer = queue_impl(max_queue_size)
+        self._histograms_buffer = queue_impl(max_queue_size)
+        self._tracing_spans_buffer = queue_impl(max_queue_size)
+        self._spans_log_buffer = queue_impl(max_queue_size)
+        self._events_buffer = queue_impl(max_queue_size)
         self._headers = {'Content-Type': 'application/octet-stream',
                          'Content-Encoding': 'gzip'}
         self._event_headers = {'Content-Type': 'application/json',

--- a/wavefront_sdk/client.py
+++ b/wavefront_sdk/client.py
@@ -326,7 +326,7 @@ class WavefrontClient(connection_handler.ConnectionHandler,
             self._points_invalid.inc()
             raise error
         try:
-            self._metrics_buffer.put(line_data)
+            self._metrics_buffer.put_nowait(line_data)
         except queue.Full as error:
             self._points_dropped.inc()
             raise error
@@ -377,7 +377,7 @@ class WavefrontClient(connection_handler.ConnectionHandler,
             self._histograms_invalid.inc()
             raise error
         try:
-            self._histograms_buffer.put(line_data)
+            self._histograms_buffer.put_nowait(line_data)
         except queue.Full as error:
             self._histograms_dropped.inc()
             raise error
@@ -438,7 +438,7 @@ class WavefrontClient(connection_handler.ConnectionHandler,
             self._spans_invalid.inc()
             raise error
         try:
-            self._tracing_spans_buffer.put(line_data)
+            self._tracing_spans_buffer.put_nowait(line_data)
         except queue.Full as error:
             self._spans_dropped.inc()
             raise error
@@ -451,7 +451,7 @@ class WavefrontClient(connection_handler.ConnectionHandler,
                 self._span_logs_invalid.inc()
                 raise error
             try:
-                self._spans_log_buffer.put(line_data)
+                self._spans_log_buffer.put_nowait(line_data)
             except queue.Full as error:
                 self._span_logs_dropped.inc()
                 raise error
@@ -524,7 +524,7 @@ class WavefrontClient(connection_handler.ConnectionHandler,
             self._events_invalid.inc()
             raise error
         try:
-            self._events_buffer.put(line_data)
+            self._events_buffer.put_nowait(line_data)
         except queue.Full as error:
             self._events_dropped.inc()
             raise error

--- a/wavefront_sdk/client_factory.py
+++ b/wavefront_sdk/client_factory.py
@@ -4,7 +4,6 @@
 """
 
 import queue
-
 from urllib.parse import urlparse
 
 from wavefront_sdk.client import WavefrontClient

--- a/wavefront_sdk/client_factory.py
+++ b/wavefront_sdk/client_factory.py
@@ -3,6 +3,8 @@
 @author Yogesh Prasad Kurmi (ykurmi@vmware.com)
 """
 
+import queue
+
 from urllib.parse import urlparse
 
 from wavefront_sdk.client import WavefrontClient
@@ -25,15 +27,24 @@ class WavefrontClientFactory:
     def add_client(self, url, max_queue_size=50000,
                    batch_size=10000,
                    flush_interval_seconds=5,
-                   enable_internal_metrics=True):
+                   enable_internal_metrics=True,
+                   queue_impl=queue.Queue):
         """Create a unique client."""
         server, token = self.get_server_info_from_endpoint(url)
 
         if self.existing_client(server):
             raise RuntimeError("client with id " + url + " already exists.")
-        self.clients.append(WavefrontClient(server, token, max_queue_size,
-                                            batch_size, flush_interval_seconds,
-                                            enable_internal_metrics))
+
+        client = WavefrontClient(
+            server=server,
+            token=token,
+            max_queue_size=max_queue_size,
+            batch_size=batch_size,
+            flush_interval_seconds=flush_interval_seconds,
+            enable_internal_metrics=enable_internal_metrics,
+            queue_impl=queue_impl,
+        )
+        self.clients.append(client)
 
     def get_server_info_from_endpoint(self, url):
         """Get Server and API token from the end point.

--- a/wavefront_sdk/common/metrics/counter.py
+++ b/wavefront_sdk/common/metrics/counter.py
@@ -12,7 +12,7 @@ class WavefrontSdkCounter(metrics.WavefrontSdkMetric):
 
     def __init__(self):
         """Construct Wavefront SDK Counter."""
-        self._lock = threading.Lock()
+        self._lock = threading.RLock()
         self._count = 0
 
     def inc(self, val=1):

--- a/wavefront_sdk/common/metrics/registry.py
+++ b/wavefront_sdk/common/metrics/registry.py
@@ -26,7 +26,7 @@ class WavefrontSdkMetricsRegistry(object):
         self.reporting_interval_secs = reporting_interval_secs
         self.metrics = {}
         self._closed = False
-        self._schedule_lock = threading.Lock()
+        self._schedule_lock = threading.RLock()
         self._timer = None
         if wf_metric_sender:
             self._schedule_timer()

--- a/wavefront_sdk/common/utils.py
+++ b/wavefront_sdk/common/utils.py
@@ -28,7 +28,7 @@ class AtomicCounter(object):
         @param initial: Initial value of the counter
         """
         self.value = initial
-        self._lock = threading.Lock()
+        self._lock = threading.RLock()
 
     def increment(self, num=1):
         """Increment atomic counter value.

--- a/wavefront_sdk/direct.py
+++ b/wavefront_sdk/direct.py
@@ -54,7 +54,8 @@ class WavefrontDirectClient(connection_handler.ConnectionHandler,
                  max_queue_size=50000,
                  batch_size=10000,
                  flush_interval_seconds=5,
-                 enable_internal_metrics=True):
+                 enable_internal_metrics=True,
+                 queue_impl=queue.Queue):
         """Construct Direct Client.
 
         @param server: Server address, Example: https://INSTANCE.wavefront.com
@@ -78,11 +79,11 @@ class WavefrontDirectClient(connection_handler.ConnectionHandler,
         self._batch_size = batch_size
         self._flush_interval_seconds = flush_interval_seconds
         self._default_source = socket.gethostname() or 'unknown'
-        self._metrics_buffer = queue.Queue(max_queue_size)
-        self._histograms_buffer = queue.Queue(max_queue_size)
-        self._tracing_spans_buffer = queue.Queue(max_queue_size)
-        self._spans_log_buffer = queue.Queue(max_queue_size)
-        self._events_buffer = queue.Queue(max_queue_size)
+        self._metrics_buffer = queue_impl(max_queue_size)
+        self._histograms_buffer = queue_impl(max_queue_size)
+        self._tracing_spans_buffer = queue_impl(max_queue_size)
+        self._spans_log_buffer = queue_impl(max_queue_size)
+        self._events_buffer = queue_impl(max_queue_size)
         self._headers = {'Content-Type': 'application/octet-stream',
                          'Content-Encoding': 'gzip',
                          'Authorization': 'Bearer ' + token}

--- a/wavefront_sdk/direct.py
+++ b/wavefront_sdk/direct.py
@@ -90,7 +90,7 @@ class WavefrontDirectClient(connection_handler.ConnectionHandler,
                                'Content-Encoding': 'gzip',
                                'Authorization': 'Bearer ' + token}
         self._closed = False
-        self._schedule_lock = threading.Lock()
+        self._schedule_lock = threading.RLock()
         self._timer = None
 
         if enable_internal_metrics:

--- a/wavefront_sdk/entities/histogram/histogram_impl.py
+++ b/wavefront_sdk/entities/histogram/histogram_impl.py
@@ -190,7 +190,7 @@ class WavefrontHistogramImpl(object):
         """
         self._clock_millis = clock_millis or self.current_clock_millis
         self._prior_minute_bins_list = []
-        self._lock = threading.Lock()
+        self._lock = threading.RLock()
         self._current_minute_bin = ThreadMinuteBin(
             self._ACCURACY, self.current_minute_millis())
 


### PR DESCRIPTION
This PR adds support for providing a different implementation of the queues used by the internal buffers.

Some applications use `multiprocessing`, and then the proper implementation to use would be `multiprocessing.Queue`, instead of `queue.Queue`.

The default queue implementation remains `queue.Queue`, and an additional initarg allows specifying a different implementation, if needed.

Also, switched from `threading.Lock` to `threading.RLock`, so re-entrant locks can be used.

Calls to `<buffer>.put()` have been switched to `<buffer>.put_nowait()`, so that we can proper handling of dropped metrics can happen, since `put()` will block indefinitely.

Version has been dumped to 1.8.5.

Thanks!
