### PR TITLE
Store clients list on `WavefrontClientFactory` instances, rather than…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(os.path.join(os.path.abspath(os.path.dirname(__file__)),
 
 setuptools.setup(
     name='wavefront-sdk-python',
-    version='1.9.0',  # Please update with each pull request.
+    version='2.0.0',  # Please update with each pull request.
     author='VMware Aria Operations for Applications Team',
     url='https://github.com/wavefrontHQ/wavefront-sdk-python',
     license='Apache-2.0',

--- a/wavefront_sdk/client_factory.py
+++ b/wavefront_sdk/client_factory.py
@@ -19,7 +19,9 @@ class WavefrontClientFactory:
     PROXY_SCHEME = "proxy"
     HTTP_PROXY_SCHEME = "http"
     DIRECT_DATA_INGESTION_SCHEME = "https"
-    clients = []
+
+    def __init__(self):
+        self.clients = []
 
     # pylint: disable=too-many-arguments
     def add_client(self, url, max_queue_size=50000,

--- a/wavefront_sdk/client_factory.py
+++ b/wavefront_sdk/client_factory.py
@@ -21,13 +21,12 @@ class WavefrontClientFactory:
     DIRECT_DATA_INGESTION_SCHEME = "https"
 
     def __init__(self):
+        """Keep track of initialized clients on instance level."""
         self.clients = []
 
     # pylint: disable=too-many-arguments
-    def add_client(self, url, max_queue_size=50000,
-                   batch_size=10000,
-                   flush_interval_seconds=5,
-                   enable_internal_metrics=True,
+    def add_client(self, url, max_queue_size=50000, batch_size=10000,
+                   flush_interval_seconds=5, enable_internal_metrics=True,
                    queue_impl=queue.Queue):
         """Create a unique client."""
         server, token = self.get_server_info_from_endpoint(url)
@@ -54,12 +53,12 @@ class WavefrontClientFactory:
         base_url = urlparse(url)
         scheme = base_url.scheme
         if scheme == self.DIRECT_DATA_INGESTION_SCHEME:
-            server = f'{self.DIRECT_DATA_INGESTION_SCHEME}://' \
-                     f'{base_url.hostname}'
+            server = (f'{self.DIRECT_DATA_INGESTION_SCHEME}://'
+                      f'{base_url.hostname}')
             token = base_url.username
         elif scheme in (self.PROXY_SCHEME, self.HTTP_PROXY_SCHEME):
-            server = f'{self.HTTP_PROXY_SCHEME}://' \
-                     f'{base_url.hostname}:{base_url.port}'
+            server = (f'{self.HTTP_PROXY_SCHEME}://'
+                      f'{base_url.hostname}:{base_url.port}')
             token = None
         else:
             raise RuntimeError("Unknown scheme specified while attempting to"


### PR DESCRIPTION
… in the class

`WavefrontClientFactory` has `clients` as a class member, which means that the list of clients is shared among different WavefrontClientFactory instances:

```
>>> from wavefront_sdk.client_factory import WavefrontClientFactory
>>> client_factory = WavefrontClientFactory()
>>> client_factory.add_client(url="http://example.com/")
>>> client_factory_two = WavefrontClientFactory()
>>> client_factory.clients
[<wavefront_sdk.client.WavefrontClient object at 0x100d10f40>]
>>> client_factory_two.clients
[<wavefront_sdk.client.WavefrontClient object at 0x100d10f40>]
```

This is surprising for users that may instantiate separate `WavefrontClientFactory`'s and expect them not to share data.

With this change:

```
>>> from wavefront_sdk.client_factory import WavefrontClientFactory
>>> client_factory = WavefrontClientFactory()
>>> client_factory.add_client(url="http://example.com/")
>>> client_factory_two = WavefrontClientFactory()
>>> client_factory.clients
[<wavefront_sdk.client.WavefrontClient object at 0x105941eb0>]
>>> client_factory_two.clients
[]
```

All better.

Closes #108.