### PR TITLE
Fix error when python 3.12 tests skips

### DIFF
--- a/.github/actions/lint_n_test/action.yml
+++ b/.github/actions/lint_n_test/action.yml
@@ -14,7 +14,7 @@ runs:
   using: composite
   steps:
     - name: Set up Python ${{ inputs.python_version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.python_version }}
         check-latest: true
@@ -40,7 +40,7 @@ runs:
       run: python -m pydocstyle
       shell: bash
     - name: Execute Unit Tests 
-      run: python -m unittest discover
+      run: python -m unittest discover -s ./test*
       shell: bash
     - name: Check Version Updated in setup.py Before Merging
       if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
         python_version: ['3.8', '3.9', '3.10', '3.11']
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - uses: wavefrontHQ/wavefront-sdk-python/.github/actions/lint_n_test@master

--- a/.github/workflows/on_merge.yml
+++ b/.github/workflows/on_merge.yml
@@ -24,7 +24,7 @@ jobs:
       PKG_REQS: ${{ inputs.requirements || needs.env0.outputs.requirements }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - uses: wavefrontHQ/wavefront-sdk-python/.github/actions/lint_n_test@master

--- a/.github/workflows/on_release.yml
+++ b/.github/workflows/on_release.yml
@@ -24,7 +24,7 @@ jobs:
       PKG_REQS: ${{ inputs.requirements || needs.env0.outputs.requirements }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - uses: wavefrontHQ/wavefront-sdk-python/.github/actions/lint_n_test@master


### PR DESCRIPTION
- Fixes error when python 3.12 tests skipped, see https://github.com/python/cpython/issues/113661 for more information
- Bump versions